### PR TITLE
Reactivate CUDA 8.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /CMakeLists.txt.user
+/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,65 @@
 cmake_minimum_required(VERSION 2.8)
 project(xmrig-cuda)
+include(cmake/CUDA-Version.cmake)
 
 
 option(WITH_DRIVER_API "Enable CUDA Driver API and NVRTC, required for cn/r and kawpow algorithms" ON)
 
+# Algorithm selection
+option(WITH_CN_R       "Enable CryptoNight-R algorithm" ON)
+option(WITH_CN_LITE    "Enable CryptoNight-Lite algorithms family" ON)
+option(WITH_CN_HEAVY   "Enable CryptoNight-Heavy algorithms family" ON)
+option(WITH_CN_PICO    "Enable CryptoNight-Pico algorithm" ON)
+option(WITH_ARGON2     "Enable Argon2 algorithms family" OFF) #unsupported
+if (CUDA_VERSION VERSION_LESS 9.0)
+    message(STATUS "CUDA ${CUDA_VERSION}: RandomX, AstroBWT, and KawPow disabled, they do not work with old CUDA")
+    option(WITH_RANDOMX  "Enable RandomX algorithms family" OFF)
+    option(WITH_ASTROBWT "Enable AstroBWT algorithms family" OFF)
+    option(WITH_KAWPOW   "Enable KawPow algorithms family" OFF)
+else()
+    option(WITH_RANDOMX  "Enable RandomX algorithms family" ON)
+    option(WITH_ASTROBWT "Enable AstroBWT algorithms family" ON)
+    option(WITH_KAWPOW   "Enable KawPow algorithms family" ON)
+endif()
+
+if (WITH_CN_R)
+    add_definitions(/DXMRIG_ALGO_CN_R)
+endif()
+
+if (WITH_CN_LITE)
+    add_definitions(/DXMRIG_ALGO_CN_LITE)
+endif()
+
+if (WITH_CN_HEAVY)
+    add_definitions(/DXMRIG_ALGO_CN_HEAVY)
+endif()
+
+if (WITH_CN_PICO)
+    add_definitions(/DXMRIG_ALGO_CN_PICO)
+endif()
+
+if (WITH_RANDOMX)
+    add_definitions(/DXMRIG_ALGO_RANDOMX)
+endif()
+
+if (WITH_ARGON2)
+    add_definitions(/DXMRIG_ALGO_ARGON2)
+endif()
+
+if (WITH_ASTROBWT)
+    add_definitions(/DXMRIG_ALGO_ASTROBWT)
+endif()
+
+if (WITH_KAWPOW)
+  if (WITH_DRIVER_API)
+    add_definitions(/DXMRIG_ALGO_KAWPOW)
+  else()
+    message(STATUS "CUDA ${CUDA_VERSION}: KawPow disabled, requires WITH_DRIVER_API=ON for CUDA Driver API and NVRTC")
+  endif()
+endif()
 
 include_directories(src)
-add_definitions(/DXMRIG_ALGO_CN_LITE /DXMRIG_ALGO_CN_HEAVY /DXMRIG_ALGO_CN_PICO)
+add_definitions(/DCUB_IGNORE_DEPRECATED_CPP_DIALECT)
 
 
 include(cmake/cpu.cmake)

--- a/cmake/CUDA-Version.cmake
+++ b/cmake/CUDA-Version.cmake
@@ -1,0 +1,27 @@
+set(DEVICE_COMPILER "nvcc")
+set(CUDA_COMPILER "${DEVICE_COMPILER}" CACHE STRING "Select the device compiler")
+
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    list(APPEND DEVICE_COMPILER "clang")
+endif()
+
+set_property(CACHE CUDA_COMPILER PROPERTY STRINGS "${DEVICE_COMPILER}")
+
+list(APPEND CMAKE_PREFIX_PATH "$ENV{CUDA_ROOT}")
+list(APPEND CMAKE_PREFIX_PATH "$ENV{CMAKE_PREFIX_PATH}")
+
+set(CUDA_STATIC ON)
+find_package(CUDA 8.0 REQUIRED)
+
+if (WITH_DRIVER_API)
+    find_library(CUDA_LIB libcuda cuda HINTS "${CUDA_TOOLKIT_ROOT_DIR}/lib64" "${LIBCUDA_LIBRARY_DIR}" "${CUDA_TOOLKIT_ROOT_DIR}/lib/x64" /usr/lib64 /usr/local/cuda/lib64)
+    find_library(CUDA_NVRTC_LIB libnvrtc nvrtc HINTS "${CUDA_TOOLKIT_ROOT_DIR}/lib64" "${LIBNVRTC_LIBRARY_DIR}" "${CUDA_TOOLKIT_ROOT_DIR}/lib/x64" /usr/lib64 /usr/local/cuda/lib64)
+
+    set(LIBS ${LIBS} ${CUDA_LIBRARIES} ${CUDA_LIB} ${CUDA_NVRTC_LIB})
+
+    add_definitions(-DXMRIG_DRIVER_API)
+else()
+    set(LIBS ${LIBS} ${CUDA_LIBRARIES})
+
+    remove_definitions(-DXMRIG_DRIVER_API)
+endif()

--- a/cmake/CUDA.cmake
+++ b/cmake/CUDA.cmake
@@ -1,36 +1,17 @@
+set(MSG_CUDA_MAP "\n\n"
+    "  Valid CUDA Toolkit Map:\n"
+    "   8.x for Fermi/Kepler/Maxwell/Pascal,\n"
+    "   9.x for       Kepler/Maxwell/Pascal/Volta,\n"
+    "  10.x for       Kepler/Maxwell/Pascal/Volta/Turing,\n"
+    "  11.x for              Maxwell/Pascal/Volta/Turing/Ampere\n\n"
+    "Reference https://developer.nvidia.com/cuda-gpus#compute for arch and family name\n\n"
+)
+
 add_definitions(-DCUB_IGNORE_DEPRECATED_CPP_DIALECT -DTHRUST_IGNORE_DEPRECATED_CPP_DIALECT)
 
 option(XMRIG_LARGEGRID "Support large CUDA block count > 128" ON)
 if (XMRIG_LARGEGRID)
     add_definitions("-DXMRIG_LARGEGRID=${XMRIG_LARGEGRID}")
-endif()
-
-set(DEVICE_COMPILER "nvcc")
-set(CUDA_COMPILER "${DEVICE_COMPILER}" CACHE STRING "Select the device compiler")
-
-if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    list(APPEND DEVICE_COMPILER "clang")
-endif()
-
-set_property(CACHE CUDA_COMPILER PROPERTY STRINGS "${DEVICE_COMPILER}")
-
-list(APPEND CMAKE_PREFIX_PATH "$ENV{CUDA_ROOT}")
-list(APPEND CMAKE_PREFIX_PATH "$ENV{CMAKE_PREFIX_PATH}")
-
-set(CUDA_STATIC ON)
-find_package(CUDA 9.0 REQUIRED)
-
-if (WITH_DRIVER_API)
-    find_library(CUDA_LIB libcuda cuda HINTS "${CUDA_TOOLKIT_ROOT_DIR}/lib64" "${LIBCUDA_LIBRARY_DIR}" "${CUDA_TOOLKIT_ROOT_DIR}/lib/x64" /usr/lib64 /usr/local/cuda/lib64)
-    find_library(CUDA_NVRTC_LIB libnvrtc nvrtc HINTS "${CUDA_TOOLKIT_ROOT_DIR}/lib64" "${LIBNVRTC_LIBRARY_DIR}" "${CUDA_TOOLKIT_ROOT_DIR}/lib/x64" /usr/lib64 /usr/local/cuda/lib64)
-
-    set(LIBS ${LIBS} ${CUDA_LIBRARIES} ${CUDA_LIB} ${CUDA_NVRTC_LIB})
-
-    add_definitions(-DXMRIG_DRIVER_API)
-else()
-    set(LIBS ${LIBS} ${CUDA_LIBRARIES})
-
-    remove_definitions(-DXMRIG_DRIVER_API)
 endif()
 
 set(DEFAULT_CUDA_ARCH "50")
@@ -40,6 +21,7 @@ if (CUDA_VERSION VERSION_LESS 9.0)
     list(APPEND DEFAULT_CUDA_ARCH "20;21")
 endif()
 
+# Kepler GPUs are only supported with CUDA < 11.0
 if (CUDA_VERSION VERSION_LESS 11.0)
     list(APPEND DEFAULT_CUDA_ARCH "30")
 else()
@@ -56,6 +38,17 @@ if (NOT CUDA_VERSION VERSION_LESS 9.0)
     list(APPEND DEFAULT_CUDA_ARCH "70")
 endif()
 
+# add Turing support for CUDA >= 10.0
+if (NOT CUDA_VERSION VERSION_LESS 10.0)
+    list(APPEND DEFAULT_CUDA_ARCH "75")
+endif()
+
+# add Ampere support for CUDA >= 11.0
+if (NOT CUDA_VERSION VERSION_LESS 11.0)
+    list(APPEND DEFAULT_CUDA_ARCH "80")
+endif()
+list(SORT DEFAULT_CUDA_ARCH)
+
 set(CUDA_ARCH "${DEFAULT_CUDA_ARCH}" CACHE STRING "Set GPU architecture (semicolon separated list, e.g. '-DCUDA_ARCH=20;35;60')")
 
 # validate architectures (only numbers are allowed)
@@ -68,13 +61,56 @@ foreach(CUDA_ARCH_ELEM ${CUDA_ARCH})
     unset(IS_NUMBER)
 
     if(${CUDA_ARCH_ELEM} LESS 20)
-        message(FATAL_ERROR "Unsupported CUDA architecture '${CUDA_ARCH_ELEM}' specified. "
-                            "Use '20' (for compute architecture 2.0) or higher.")
+        message("${MSG_CUDA_MAP}")
+        message(FATAL_ERROR "Unsupported CUDA architecture '${CUDA_ARCH_ELEM}' specified.")
+    endif()
+
+    if (NOT CUDA_VERSION VERSION_LESS 11.0)
+        if(${CUDA_ARCH_ELEM} LESS 50)
+            message("${MSG_CUDA_MAP}")
+            message(FATAL_ERROR "Unsupported CUDA architecture '${CUDA_ARCH_ELEM}' specified. "
+                                "Use CUDA v10.x maximum, Kepler (30/35/37) was dropped at v11.")
+        endif()
+    else()
+        if(NOT ${CUDA_ARCH_ELEM} LESS 80)
+            message("${MSG_CUDA_MAP}")
+            message(FATAL_ERROR "Unsupported CUDA architecture '${CUDA_ARCH_ELEM}' specified. "
+                                "Use CUDA v11.x minimum, Ampere (80) was added at v11.")
+        endif()
+    endif()
+
+    if (CUDA_VERSION VERSION_LESS 10.0)
+        if(NOT ${CUDA_ARCH_ELEM} LESS 75)
+            message("${MSG_CUDA_MAP}")
+            message(FATAL_ERROR "Unsupported CUDA architecture '${CUDA_ARCH_ELEM}' specified. "
+                                "Use CUDA v10.x minimum, Turing (75) was added at v10.")
+        endif()
+    endif()
+
+    if (NOT CUDA_VERSION VERSION_LESS 9.0)
+        if(${CUDA_ARCH_ELEM} LESS 30)
+            message("${MSG_CUDA_MAP}")
+            message(FATAL_ERROR "Unsupported CUDA architecture '${CUDA_ARCH_ELEM}' specified. "
+                                "Use CUDA v8.x maximum, Fermi (20/21) was dropped at v9.")
+        endif()
+    else()
+        if(NOT ${CUDA_ARCH_ELEM} LESS 70)
+            message("${MSG_CUDA_MAP}")
+            message(FATAL_ERROR "Unsupported CUDA architecture '${CUDA_ARCH_ELEM}' specified. "
+                                "Use CUDA v9.x minimum, Volta (70/72) was added at v9.")
+        endif()
     endif()
 endforeach()
 
+unset(MSG_CUDA_MAP)
 list(SORT CUDA_ARCH)
 
+add_definitions(-DCUB_IGNORE_DEPRECATED_CPP_DIALECT -DTHRUST_IGNORE_DEPRECATED_CPP_DIALECT)
+
+option(XMRIG_LARGEGRID "Support large CUDA block count > 128" ON)
+if (XMRIG_LARGEGRID)
+    add_definitions("-DXMRIG_LARGEGRID=${XMRIG_LARGEGRID}")
+endif()
 option(CUDA_SHOW_REGISTER "Show registers used for each kernel and compute architecture" OFF)
 option(CUDA_KEEP_FILES "Keep all intermediate files that are generated during internal compilation steps" OFF)
 
@@ -141,6 +177,48 @@ else()
     message(FATAL_ERROR "selected CUDA compiler '${CUDA_COMPILER}' is not supported")
 endif()
 
+if (WITH_RANDOMX)
+    set(CUDA_RANDOMX_SOURCES
+        src/RandomX/aes_cuda.hpp
+        src/RandomX/arqma/configuration.h
+        src/RandomX/arqma/randomx_arqma.cu
+        src/RandomX/blake2b_cuda.hpp
+        src/RandomX/common.hpp
+        src/RandomX/hash.hpp
+        src/RandomX/keva/configuration.h
+        src/RandomX/keva/randomx_keva.cu
+        src/RandomX/monero/configuration.h
+        src/RandomX/monero/randomx_monero.cu
+        src/RandomX/randomx_cuda.hpp
+        src/RandomX/randomx.cu
+        src/RandomX/wownero/configuration.h
+        src/RandomX/wownero/randomx_wownero.cu
+    )
+else()
+    set(CUDA_RANDOMX_SOURCES "")
+endif()
+
+if (WITH_ASTROBWT)
+    set(CUDA_ASTROBWT_SOURCES
+        src/AstroBWT/dero/AstroBWT.cu
+        src/AstroBWT/dero/BWT.h
+        src/AstroBWT/dero/salsa20.h
+        src/AstroBWT/dero/sha3.h
+    )
+else()
+    set(CUDA_ASTROBWT_SOURCES "")
+endif()
+
+if (WITH_KAWPOW AND WITH_DRIVER_API)
+    set(CUDA_KAWPOW_SOURCES
+        src/KawPow/raven/CudaKawPow_gen.cpp
+        src/KawPow/raven/CudaKawPow_gen.h
+        src/KawPow/raven/KawPow.cu
+    )
+else()
+    set(CUDA_KAWPOW_SOURCES "")
+endif()
+
 set(CUDA_SOURCES
     src/cryptonight.h
     src/cuda_aes.hpp
@@ -154,39 +232,10 @@ set(CUDA_SOURCES
     src/cuda_jh.hpp
     src/cuda_keccak.hpp
     src/cuda_skein.hpp
+    ${CUDA_RANDOMX_SOURCES}
+    ${CUDA_ASTROBWT_SOURCES}
+    ${CUDA_KAWPOW_SOURCES}
 )
-
-list(APPEND CUDA_SOURCES
-    src/RandomX/aes_cuda.hpp
-    src/RandomX/arqma/configuration.h
-    src/RandomX/arqma/randomx_arqma.cu
-    src/RandomX/blake2b_cuda.hpp
-    src/RandomX/common.hpp
-    src/RandomX/hash.hpp
-    src/RandomX/keva/configuration.h
-    src/RandomX/keva/randomx_keva.cu
-    src/RandomX/monero/configuration.h
-    src/RandomX/monero/randomx_monero.cu
-    src/RandomX/randomx_cuda.hpp
-    src/RandomX/randomx.cu
-    src/RandomX/wownero/configuration.h
-    src/RandomX/wownero/randomx_wownero.cu
-)
-
-list(APPEND CUDA_SOURCES
-    src/AstroBWT/dero/AstroBWT.cu
-    src/AstroBWT/dero/BWT.h
-    src/AstroBWT/dero/salsa20.h
-    src/AstroBWT/dero/sha3.h
-)
-
-if (WITH_DRIVER_API)
-    list(APPEND CUDA_SOURCES
-        src/KawPow/raven/CudaKawPow_gen.cpp
-        src/KawPow/raven/CudaKawPow_gen.h
-        src/KawPow/raven/KawPow.cu
-    )
-endif()
 
 if("${CUDA_COMPILER}" STREQUAL "clang")
     add_library(xmrig-cu STATIC ${CUDA_SOURCES})

--- a/src/crypto/cn/CnAlgo.h
+++ b/src/crypto/cn/CnAlgo.h
@@ -152,8 +152,8 @@ public:
 #       endif
 #       ifdef XMRIG_ALGO_CN_HEAVY
         case Algorithm::CN_HEAVY_TUBE:
-            return Algorithm::CN_1;
 #       endif
+            return Algorithm::CN_1;
 
         case Algorithm::CN_2:
         case Algorithm::CN_R:

--- a/src/crypto/common/Algorithm.cpp
+++ b/src/crypto/common/Algorithm.cpp
@@ -74,8 +74,10 @@ static AlgoName const algorithm_names[] = {
     { "cn-pico/tlo",      Algorithm::CN_PICO_TLO     },
     { "cn/ccx",           Algorithm::CN_CCX          },
     { "astrobwt",         Algorithm::ASTROBWT_DERO   },
+    { "astrobwt/dero",    Algorithm::ASTROBWT_DERO   },
 #   ifdef XMRIG_DRIVER_API
     { "kawpow",           Algorithm::KAWPOW_RVN      },
+    { "kawpow/rvn",       Algorithm::KAWPOW_RVN      },
     { "cn/r",             Algorithm::CN_R            },
 #   endif
 };

--- a/src/xmrig-cuda.cpp
+++ b/src/xmrig-cuda.cpp
@@ -174,6 +174,7 @@ bool rxHash(nvid_ctx *ctx, uint32_t startNonce, uint64_t target, uint32_t *resco
 
     try {
         switch (ctx->algorithm.id()) {
+#       ifdef XMRIG_ALGO_RANDOMX
         case Algorithm::RX_0:
         case Algorithm::RX_SFX:
             RandomX_Monero::hash(ctx, startNonce, target, rescount, resnonce, ctx->rx_batch_size);
@@ -190,6 +191,7 @@ bool rxHash(nvid_ctx *ctx, uint32_t startNonce, uint64_t target, uint32_t *resco
         case Algorithm::RX_KEVA:
             RandomX_Keva::hash(ctx, startNonce, target, rescount, resnonce, ctx->rx_batch_size);
             break;
+#       endif
 
         default:
             throw std::runtime_error(kUnsupportedAlgorithm);
@@ -210,7 +212,11 @@ bool rxPrepare(nvid_ctx *ctx, const void *dataset, size_t datasetSize, bool, uin
     resetError(ctx->device_id);
 
     try {
+#       ifdef XMRIG_ALGO_RANDOMX
         randomx_prepare(ctx, ctx->rx_dataset_host > 0 ? datasetHost.reg(dataset, datasetSize) : dataset, datasetSize, batchSize);
+#       else
+        throw std::runtime_error(kUnsupportedAlgorithm);
+#       endif
     }
     catch (std::exception &ex) {
         saveError(ctx->device_id, ex);
@@ -224,13 +230,17 @@ bool rxPrepare(nvid_ctx *ctx, const void *dataset, size_t datasetSize, bool, uin
 
 bool astroBWTHash(nvid_ctx *ctx, uint32_t startNonce, uint64_t target, uint32_t *rescount, uint32_t *resnonce)
 {
+    using namespace xmrig_cuda;
+
     resetError(ctx->device_id);
 
     try {
         switch (ctx->algorithm.id()) {
-        case xmrig_cuda::Algorithm::ASTROBWT_DERO:
+#       ifdef XMRIG_ALGO_ASTROBWT
+        case Algorithm::ASTROBWT_DERO:
             AstroBWT_Dero::hash(ctx, startNonce, target, rescount, resnonce);
             break;
+#       endif
 
         default:
             throw std::runtime_error(kUnsupportedAlgorithm);
@@ -251,7 +261,11 @@ bool astroBWTPrepare(nvid_ctx *ctx, uint32_t batchSize)
     resetError(ctx->device_id);
 
     try {
+#       ifdef XMRIG_ALGO_ASTROBWT
         astrobwt_prepare(ctx, batchSize);
+#       else
+        throw std::runtime_error(kUnsupportedAlgorithm);
+#       endif
     }
     catch (std::exception &ex) {
         saveError(ctx->device_id, ex);
@@ -265,14 +279,18 @@ bool astroBWTPrepare(nvid_ctx *ctx, uint32_t batchSize)
 
 bool kawPowHash(nvid_ctx *ctx, uint8_t* job_blob, uint64_t target, uint32_t *rescount, uint32_t *resnonce, uint32_t *skipped_hashes)
 {
+    using namespace xmrig_cuda;
+
 #   ifdef XMRIG_DRIVER_API
     resetError(ctx->device_id);
 
     try {
         switch (ctx->algorithm.id()) {
-        case xmrig_cuda::Algorithm::KAWPOW_RVN:
+#       ifdef XMRIG_ALGO_KAWPOW
+        case Algorithm::KAWPOW_RVN:
             KawPow_Raven::hash(ctx, job_blob, target, rescount, resnonce, skipped_hashes);
             break;
+#       endif
 
         default:
             throw std::runtime_error(kUnsupportedAlgorithm);
@@ -299,7 +317,11 @@ bool kawPowPrepare(nvid_ctx *ctx, const void* cache, size_t cache_size, size_t d
     resetError(ctx->device_id);
 
     try {
+#       ifdef XMRIG_ALGO_KAWPOW
         kawpow_prepare(ctx, cache, cache_size, nullptr, dag_size, height, dag_sizes);
+#       else
+        throw std::runtime_error(kUnsupportedAlgorithm);
+#       endif
     }
     catch (std::exception &ex) {
         saveError(ctx->device_id, ex);
@@ -322,7 +344,11 @@ bool kawPowPrepare_v2(nvid_ctx *ctx, const void* cache, size_t cache_size, const
     resetError(ctx->device_id);
 
     try {
+#       ifdef XMRIG_ALGO_KAWPOW
         kawpow_prepare(ctx, cache, cache_size, dag_precalc, dag_size, height, dag_sizes);
+#       else
+        throw std::runtime_error(kUnsupportedAlgorithm);
+#       endif
     }
     catch (std::exception &ex) {
         saveError(ctx->device_id, ex);
@@ -343,7 +369,11 @@ bool kawPowStopHash(nvid_ctx *ctx)
 {
 #   ifdef XMRIG_DRIVER_API
     try {
+#       ifdef XMRIG_ALGO_KAWPOW
         kawpow_stop_hash(ctx);
+#       else
+        throw std::runtime_error(kUnsupportedAlgorithm);
+#       endif
     }
     catch (std::exception &ex) {
         saveError(ctx->device_id, ex);


### PR DESCRIPTION
```
Enable algo options and full code omissions of disabled algos;
Reactivates CUDA 8.0
```

Allows for completely shutting off code that won't compile on CUDA 8.0 (RandomX, AstroBWT, and KawPow) while the resulting plugin works great for the other possible algos.

Compiling with CUDA 8.0 (or other versions) was accomplished in the added `cmake/CUDA-Version.cmake` which moves the CUDA Toolkit detections a step earlier so the main `CMakeLists.txt` can make decisions and route the user more appropriately to a working result.  For example, compiling with an arch 20 option with some newer CUDA will explain why it won't work.

Any disabled algos will throw an unsupported condition so the plugin API still works appropriately, even with chunks of code carved out.  Very similar to how the main miner does algo selections.

Have used very similar patch for quite some time now to compile working miners for arch-20 (or 21) devices.  It is well tested in all my use cases.