### PR TITLE
Fix build on MacOS 10.13 (last supported OSX for CUDA)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,10 @@ if (XMRIG_OS_WIN)
     list(APPEND SOURCES res/app.rc)
 endif()
 
+if (XMRIG_OS_APPLE)
+    cmake_policy(SET CMP0042 NEW)
+endif()
+
 add_library(${CMAKE_PROJECT_NAME} SHARED ${SOURCES})
 target_link_libraries(${CMAKE_PROJECT_NAME} xmrig-cu ${LIBS})
 

--- a/cmake/CUDA.cmake
+++ b/cmake/CUDA.cmake
@@ -115,8 +115,26 @@ option(CUDA_SHOW_REGISTER "Show registers used for each kernel and compute archi
 option(CUDA_KEEP_FILES "Keep all intermediate files that are generated during internal compilation steps" OFF)
 
 if (WITH_DRIVER_API)
-    find_library(CUDA_LIB libcuda cuda HINTS "${CUDA_TOOLKIT_ROOT_DIR}/lib64" "${LIBCUDA_LIBRARY_DIR}" "${CUDA_TOOLKIT_ROOT_DIR}/lib/x64" /usr/lib64 /usr/local/cuda/lib64)
-    find_library(CUDA_NVRTC_LIB libnvrtc nvrtc HINTS "${CUDA_TOOLKIT_ROOT_DIR}/lib64" "${LIBNVRTC_LIBRARY_DIR}" "${CUDA_TOOLKIT_ROOT_DIR}/lib/x64" /usr/lib64 /usr/local/cuda/lib64)
+    set(CUDA_LIB_HINTS "${LIBCUDA_LIBRARY_DIR}")
+    set(CUDA_NVRTC_LIB_HINTS "${LIBNVRTC_LIBRARY_DIR}")
+    if (XMRIG_OS_APPLE)
+        list(APPEND CUDA_LIB_HINTS "${CUDA_TOOLKIT_ROOT_DIR}/lib")
+        list(APPEND CUDA_NVRTC_LIB_HINTS "${CUDA_TOOLKIT_ROOT_DIR}/lib")
+    else()
+        set(LIB_HINTS
+            "${CUDA_TOOLKIT_ROOT_DIR}/lib64"
+            "${CUDA_TOOLKIT_ROOT_DIR}/lib/x64"
+            "/usr/lib64"
+            "/usr/local/cuda/lib64"
+            )
+        list(APPEND CUDA_LIB_HINTS ${LIB_HINTS})
+        list(APPEND CUDA_NVRTC_LIB_HINTS ${LIB_HINTS})
+        unset(LIB_HINTS)
+    endif()
+    find_library(CUDA_LIB libcuda cuda HINTS ${CUDA_LIB_HINTS})
+    find_library(CUDA_NVRTC_LIB libnvrtc nvrtc HINTS ${CUDA_NVRTC_LIB_HINTS})
+    unset(CUDA_LIB_HINTS)
+    unset(CUDA_NVRTC_LIB_HINTS)
 
     list(APPEND LIBS ${CUDA_LIB} ${CUDA_NVRTC_LIB})
 endif()

--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -85,6 +85,11 @@ elseif (CMAKE_CXX_COMPILER_ID MATCHES Clang)
         endif()
     endif()
 
+    if (XMRIG_OS_APPLE)
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+    endif()
+
 endif()
 
 if (NOT WIN32)


### PR DESCRIPTION
Previously the configure step could not find CUDA or NVRTC libraries within Toolkit directory.  When `XMRIG_OS_APPLE` is set, search the correct subdirectories.  Clean up the default search path for all non-Apple.

MacOS High Sierra (10.13) compiler is customized clang 10.0.0 and needs `-std=` added to CFLAGS as `c99`/`c++11` are not default, leading to compilation crashes.

Mute [CMP0042 warning](https://cmake.org/cmake/help/latest/policy/CMP0042.html) by setting policy to `NEW`; it doesn't seem like it matters, or policy `NEW` already works.