### PR TITLE
add cstddef explicitly for GCC11

### DIFF
--- a/src/crypto/common/Algorithm.h
+++ b/src/crypto/common/Algorithm.h
@@ -22,6 +22,7 @@
 
 
 #include <cstdint>
+#include <cstddef>
 #include <vector>
 
 


### PR DESCRIPTION
On ArchLinux with CUDA 11.4 and GCC11, one gets the following error message when compile xmrig-cuda:

~~~sh
[ 82%] Building CXX object CMakeFiles/xmrig-cuda.dir/src/crypto/common/Algorithm.cpp.o
In file included from /home/dragonek/.cache/paru/clone/xmrig-cuda/src/xmrig-cuda-6.15.0/src/crypto/common/Algorithm.cpp:20:
/home/dragonek/.cache/paru/clone/xmrig-cuda/src/xmrig-cuda-6.15.0/src/crypto/common/Algorithm.h:88:29: error: ‘size_t’ does not name a type
   88 |     static inline constexpr size_t l2(Id id)                { return family(id) == RANDOM_X ? (1U << ((id >> 8) & 0xff)) : 0U; }
      |                             ^~~~~~
In file included from /home/dragonek/.cache/paru/clone/xmrig-cuda/src/xmrig-cuda-6.15.0/src/crypto/common/Algorithm.cpp:20:
/home/dragonek/.cache/paru/clone/xmrig-cuda/src/xmrig-cuda-6.15.0/src/crypto/common/Algorithm.h:25:1: note: ‘size_t’ is defined in header ‘<cstddef>’; did you forget to ‘#include <cstddef>’?
   24 | #include <vector>
  +++ |+#include <cstddef>
   25 | 
In file included from /home/dragonek/.cache/paru/clone/xmrig-cuda/src/xmrig-cuda-6.15.0/src/crypto/common/Algorithm.cpp:20:
/home/dragonek/.cache/paru/clone/xmrig-cuda/src/xmrig-cuda-6.15.0/src/crypto/common/Algorithm.h:89:29: error: ‘size_t’ does not name a type
   89 |     static inline constexpr size_t l3(Id id)                { return 1ULL << ((id >> 16) & 0xff); }
      |                             ^~~~~~
/home/dragonek/.cache/paru/clone/xmrig-cuda/src/xmrig-cuda-6.15.0/src/crypto/common/Algorithm.h:89:29: note: ‘size_t’ is defined in header ‘<cstddef>’; did you forget to ‘#include <cstddef>’?
/home/dragonek/.cache/paru/clone/xmrig-cuda/src/xmrig-cuda-6.15.0/src/crypto/common/Algorithm.h:97:12: error: ‘size_t’ does not name a type
   97 |     inline size_t l2() const                                { return l2(m_id); }
      |            ^~~~~~
/home/dragonek/.cache/paru/clone/xmrig-cuda/src/xmrig-cuda-6.15.0/src/crypto/common/Algorithm.h:97:12: note: ‘size_t’ is defined in header ‘<cstddef>’; did you forget to ‘#include <cstddef>’?
/home/dragonek/.cache/paru/clone/xmrig-cuda/src/xmrig-cuda-6.15.0/src/crypto/common/Algorithm.h:101:12: error: ‘size_t’ does not name a type
  101 |     inline size_t l3() const
      |            ^~~~~~
/home/dragonek/.cache/paru/clone/xmrig-cuda/src/xmrig-cuda-6.15.0/src/crypto/common/Algorithm.h:101:12: note: ‘size_t’ is defined in header ‘<cstddef>’; did you forget to ‘#include <cstddef>’?
~~~

Clearly `size_t` is not defined, and including `<cstddef>` solves this. I know that with GCC4/5 that cstddef was pulled out of a lot of headers, making it necessary to explicitly include it. Maybe with GCC11 this also happened; the GNU release notes don't list this though.