### PR TITLE
Error compiling under Linux

### DIFF
--- a/src/crypto/common/Algorithm.h
+++ b/src/crypto/common/Algorithm.h
@@ -20,6 +20,9 @@
 #ifndef XMRIG_ALGORITHM_H
 #define XMRIG_ALGORITHM_H
 
+#ifndef uint32_t
+  #include <cstdint>
+#endif
 
 #include <vector>
 


### PR DESCRIPTION
Error:
xmrig-cuda-master/src/crypto/common/Algorithm.h(33): error: forward declaration of enum type is nonstandard
xmrig-cuda-master/src/crypto/common/Algorithm.h(33): error: identifier "uint32_t" is undefined
xmrig-cuda-master/src/crypto/common/Algorithm.h(33): error: incomplete type is not allowed
xmrig-cuda-master/src/crypto/common/Algorithm.h(33): error: expected a ";"
...

uname -a
Linux localhost 5.10.60-desktop-2.mga8 #1 SMP Wed Aug 18 11:12:31 UTC 2021 x86_64 x86_64 x86_64 GNU/Linux

gcc version 10.3.0 (Mageia 10.3.0-2.mga8) 
cuda-toolkit 11.2