### PR TITLE
CUDA cannot restart -  randomx_prepare>:36 "invalid argument"

### DIFF
--- a/src/xmrig-cuda.cpp
+++ b/src/xmrig-cuda.cpp
@@ -68,6 +68,7 @@ public:
         if (m_refs == 0) {
             cudaHostUnregister(m_ptr);
         }
+        m_ptr = nullptr;
     }
 
     int32_t m_refs  = 0;


### PR DESCRIPTION
it will repair error while cuda restarting:
   nvidia thread #0 failed with error <randomx_prepare>:36 "invalid argument"

issue:https://github.com/xmrig/xmrig-cuda/issues/123