### PR TITLE
Use cstddef header to pull in size_t for GCC 5 and 6

### DIFF
--- a/src/crypto/common/Algorithm.h
+++ b/src/crypto/common/Algorithm.h
@@ -21,6 +21,7 @@
 #define XMRIG_ALGORITHM_H
 
 
+#include <cstddef>
 #include <cstdint>
 #include <vector>
 


### PR DESCRIPTION
Compiling for CUDA Toolkit 8.0 or 9.1 where maximum GCC is 5 or 6 crashed with:
```
In file included from /usr/src/xmrig-cuda/src/crypto/common/Algorithm.cpp:20:0:
/usr/src/xmrig-cuda/src/crypto/common/Algorithm.h:89:29: error: ‘size_t’ does not name a type
     static inline constexpr size_t l2(Id id)                { return family(id) == RANDOM_X ? (1U << ((id >> 8) & 0xff)) : 0U; }
                             ^~~~~~
/usr/src/xmrig-cuda/src/crypto/common/Algorithm.h:90:29: error: ‘size_t’ does not name a type
     static inline constexpr size_t l3(Id id)                { return 1ULL << ((id >> 16) & 0xff); }
                             ^~~~~~
/usr/src/xmrig-cuda/src/crypto/common/Algorithm.h:98:12: error: ‘size_t’ does not name a type
     inline size_t l2() const                                { return l2(m_id); }
            ^~~~~~
/usr/src/xmrig-cuda/src/crypto/common/Algorithm.h:102:12: error: ‘size_t’ does not name a type
     inline size_t l3() const
            ^~~~~~
```

Comparison with the upstream/main xmrig Algorithm.h showed that including `<functional>` makes it work again.  Wrapped that inside a GCC version test since it seems to not be needed anymore with gcc7 or newer.  Remove the ifdef wrapping if it doesn't matter (it probably doesn't, there is no wrap in main xmrig file).