### PR TITLE
fix for 'size_t' does not name a type

### DIFF
--- a/src/crypto/common/Algorithm.h
+++ b/src/crypto/common/Algorithm.h
@@ -23,6 +23,7 @@
 
 #include <cstdint>
 #include <vector>
+#include <cstddef>
 
 
 namespace xmrig_cuda {


### PR DESCRIPTION
there was a missing headers, added the same; and it worked on Arch and PopOs.