### PR TITLE
Support `bsleep` for KawPow

### DIFF
--- a/src/KawPow/raven/KawPow.cu
+++ b/src/KawPow/raven/KawPow.cu
@@ -147,6 +147,12 @@ void hash(nvid_ctx *ctx, uint8_t* job_blob, uint64_t target, uint32_t *rescount,
         block.x, block.y, block.z,
         0, nullptr, args, 0
     ));
+
+    // Only sleep if it's >100 to have backwards compatibility (default value of 25 will be ignored)
+    if (ctx->device_bsleep > 100) {
+        compat_usleep(ctx->device_bsleep);
+    }
+
     CU_CHECK(ctx->device_id, cuCtxSynchronize());
 
     *skipped_hashes = ctx->kawpow_stop_host[1];

--- a/src/cuda_core.cu
+++ b/src/cuda_core.cu
@@ -34,7 +34,7 @@
 
 #ifdef _WIN32
 #include <Windows.h>
-static void compat_usleep(int waitTime)
+void compat_usleep(int waitTime)
 {
     if (waitTime > 0) {
         if (waitTime > 100) {
@@ -67,7 +67,7 @@ static void compat_usleep(int waitTime)
 }
 #else
 #include <unistd.h>
-static inline void compat_usleep(int waitTime)
+void compat_usleep(int waitTime)
 {
     usleep(static_cast<uint64_t>(waitTime));
 }

--- a/src/cuda_device.hpp
+++ b/src/cuda_device.hpp
@@ -42,3 +42,5 @@
 }                                                                                                       \
 ( (void) 0 )
 #endif
+
+void compat_usleep(int waitTime);


### PR DESCRIPTION
bsleep = 10000 and blocks = 1024 reduced GPU load from 100% to 57% on RTX 4060, so it is working as intended.

See https://github.com/xmrig/xmrig/issues/3735