### PR TITLE
Add support for rx/2 and CUDA 13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 - Added support for `rx/2` (RandomX / Monero v2).
+- Added compatibility fixes for CUDA 13 builds.
 
 # v6.22.1
 - [#205](https://github.com/xmrig/xmrig-cuda/pull/205) Fixed RandomX dataset update. Fix works together with the updated XMRig.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- Added support for `rx/2` (RandomX / Monero v2).
+
 # v6.22.1
 - [#205](https://github.com/xmrig/xmrig-cuda/pull/205) Fixed RandomX dataset update. Fix works together with the updated XMRig.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,10 +107,14 @@ if (WITH_DRIVER_API AND WIN32)
         file(GLOB NVRTCDLL "${CUDA_TOOLKIT_ROOT_DIR}/bin/nvrtc64*_0.dll")
     endif()
 
-    add_custom_command(TARGET ${CMAKE_PROJECT_NAME} POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "${NVRTCDLL}" $<TARGET_FILE_DIR:${CMAKE_PROJECT_NAME}>)
+    if (NVRTCDLL)
+        add_custom_command(TARGET ${CMAKE_PROJECT_NAME} POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different "${NVRTCDLL}" $<TARGET_FILE_DIR:${CMAKE_PROJECT_NAME}>)
+    endif()
 
     file(GLOB NVRTCBUILTINDLL "${CUDA_TOOLKIT_ROOT_DIR}/bin/nvrtc-builtins64*.dll")
-    add_custom_command(TARGET ${CMAKE_PROJECT_NAME} POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "${NVRTCBUILTINDLL}" $<TARGET_FILE_DIR:${CMAKE_PROJECT_NAME}>)
+    if (NVRTCBUILTINDLL)
+        add_custom_command(TARGET ${CMAKE_PROJECT_NAME} POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different "${NVRTCBUILTINDLL}" $<TARGET_FILE_DIR:${CMAKE_PROJECT_NAME}>)
+    endif()
 endif()

--- a/cmake/CUDA.cmake
+++ b/cmake/CUDA.cmake
@@ -231,6 +231,8 @@ if (WITH_RANDOMX)
         src/RandomX/hash.hpp
         src/RandomX/monero/configuration.h
         src/RandomX/monero/randomx_monero.cu
+        src/RandomX/monero_v2/configuration.h
+        src/RandomX/monero_v2/randomx_monero_v2.cu
         src/RandomX/randomx_cuda.hpp
         src/RandomX/randomx.cu
         src/RandomX/wownero/configuration.h

--- a/src/RandomX/blake2b_cuda.hpp
+++ b/src/RandomX/blake2b_cuda.hpp
@@ -124,24 +124,30 @@ template<> __device__ uint64_t rotr64<16>(uint64_t a)
 
 #define BLAKE2B_ROUNDS() ROUND(0);ROUND(1);ROUND(2);ROUND(3);ROUND(4);ROUND(5);ROUND(6);ROUND(7);ROUND(8);ROUND(9);ROUND(10);ROUND(11);
 
-__device__ void blake2b_512_process_single_block(uint64_t *h, const uint64_t* m, uint32_t in_len)
+template<uint32_t out_len>
+__device__ void blake2b_process_single_block(uint64_t *out, const uint64_t* m, uint32_t in_len)
 {
 	uint64_t v[16] =
 	{
-		Blake2b_IV::iv0 ^ 0x01010040ul, Blake2b_IV::iv1, Blake2b_IV::iv2, Blake2b_IV::iv3, Blake2b_IV::iv4         , Blake2b_IV::iv5,  Blake2b_IV::iv6, Blake2b_IV::iv7,
+		Blake2b_IV::iv0 ^ (0x01010000ul | out_len), Blake2b_IV::iv1, Blake2b_IV::iv2, Blake2b_IV::iv3, Blake2b_IV::iv4         , Blake2b_IV::iv5,  Blake2b_IV::iv6, Blake2b_IV::iv7,
 		Blake2b_IV::iv0               , Blake2b_IV::iv1, Blake2b_IV::iv2, Blake2b_IV::iv3, Blake2b_IV::iv4 ^ in_len, Blake2b_IV::iv5, ~Blake2b_IV::iv6, Blake2b_IV::iv7,
 	};
 
 	BLAKE2B_ROUNDS();
 
-	h[0] = v[0] ^ v[ 8] ^ Blake2b_IV::iv0 ^ 0x01010040ul;
-	h[1] = v[1] ^ v[ 9] ^ Blake2b_IV::iv1;
-	h[2] = v[2] ^ v[10] ^ Blake2b_IV::iv2;
-	h[3] = v[3] ^ v[11] ^ Blake2b_IV::iv3;
-	h[4] = v[4] ^ v[12] ^ Blake2b_IV::iv4;
-	h[5] = v[5] ^ v[13] ^ Blake2b_IV::iv5;
-	h[6] = v[6] ^ v[14] ^ Blake2b_IV::iv6;
-	h[7] = v[7] ^ v[15] ^ Blake2b_IV::iv7;
+	if (out_len >  0) out[0] = v[0] ^ v[ 8] ^ Blake2b_IV::iv0 ^ (0x01010000ul | out_len);
+	if (out_len >  8) out[1] = v[1] ^ v[ 9] ^ Blake2b_IV::iv1;
+	if (out_len > 16) out[2] = v[2] ^ v[10] ^ Blake2b_IV::iv2;
+	if (out_len > 24) out[3] = v[3] ^ v[11] ^ Blake2b_IV::iv3;
+	if (out_len > 32) out[4] = v[4] ^ v[12] ^ Blake2b_IV::iv4;
+	if (out_len > 40) out[5] = v[5] ^ v[13] ^ Blake2b_IV::iv5;
+	if (out_len > 48) out[6] = v[6] ^ v[14] ^ Blake2b_IV::iv6;
+	if (out_len > 56) out[7] = v[7] ^ v[15] ^ Blake2b_IV::iv7;
+}
+
+__device__ void blake2b_512_process_single_block(uint64_t *h, const uint64_t* m, uint32_t in_len)
+{
+	blake2b_process_single_block<64>(h, m, in_len);
 }
 
 template<uint32_t out_len>

--- a/src/RandomX/common.hpp
+++ b/src/RandomX/common.hpp
@@ -23,6 +23,24 @@ along with RandomX CUDA.  If not, see<http://www.gnu.org/licenses/>.
 #include <cstdint>
 
 
+#ifndef RANDOMX_TWEAK_V2_CFROUND
+#   define RANDOMX_TWEAK_V2_CFROUND 0
+#endif
+
+#ifndef RANDOMX_TWEAK_V2_AES
+#   define RANDOMX_TWEAK_V2_AES 0
+#endif
+
+#ifndef RANDOMX_TWEAK_V2_PREFETCH
+#   define RANDOMX_TWEAK_V2_PREFETCH 0
+#endif
+
+#ifndef RANDOMX_TWEAK_V2_COMMITMENT
+#   define RANDOMX_TWEAK_V2_COMMITMENT 0
+#endif
+
+
+#define RANDOMX_HASH_SIZE          32
 #define RANDOMX_DATASET_ITEM_SIZE  64
 #define RANDOMX_DATASET_EXTRA_SIZE 33554368
 #define RANDOMX_JUMP_BITS          8

--- a/src/RandomX/hash.hpp
+++ b/src/RandomX/hash.hpp
@@ -32,6 +32,112 @@ __global__ void find_shares(const void* hashes, uint64_t target, uint32_t* share
     }
 }
 
+#if RANDOMX_TWEAK_V2_COMMITMENT
+__global__ void blake2b_hash_commitment_single(void *hashes, const void *blockTemplate, uint32_t blockTemplate_len, uint32_t start_nonce, uint32_t nonce_offset)
+{
+    const uint32_t global_index = blockIdx.x * blockDim.x + threadIdx.x;
+    const uint8_t *input = (const uint8_t *) blockTemplate;
+    const uint8_t *raw_hash = ((const uint8_t *) hashes) + global_index * 32;
+
+    uint64_t block[16] = { 0 };
+    uint8_t *msg = (uint8_t *) block;
+
+    for (uint32_t i = 0; i < blockTemplate_len; ++i) {
+        msg[i] = input[i];
+    }
+
+    const uint32_t nonce = start_nonce + global_index;
+    msg[nonce_offset + 0] = static_cast<uint8_t>(nonce);
+    msg[nonce_offset + 1] = static_cast<uint8_t>(nonce >> 8);
+    msg[nonce_offset + 2] = static_cast<uint8_t>(nonce >> 16);
+    msg[nonce_offset + 3] = static_cast<uint8_t>(nonce >> 24);
+
+    for (uint32_t i = 0; i < RANDOMX_HASH_SIZE; ++i) {
+        msg[blockTemplate_len + i] = raw_hash[i];
+    }
+
+    const uint32_t total_len = blockTemplate_len + RANDOMX_HASH_SIZE;
+    if (total_len % sizeof(uint64_t)) {
+        block[total_len / sizeof(uint64_t)] &= uint64_t(-1) >> (64 - (total_len % sizeof(uint64_t)) * 8);
+    }
+
+    uint64_t commitment[4] = { 0 };
+    blake2b_process_single_block<RANDOMX_HASH_SIZE>(commitment, block, total_len);
+
+    uint64_t *out = ((uint64_t *) hashes) + global_index * (RANDOMX_HASH_SIZE / sizeof(uint64_t));
+    out[0] = commitment[0];
+    out[1] = commitment[1];
+    out[2] = commitment[2];
+    out[3] = commitment[3];
+}
+
+__global__ void blake2b_hash_commitment_big(void *hashes, const void *blockTemplate, uint32_t blockTemplate_len, uint32_t start_nonce, uint32_t nonce_offset)
+{
+    const uint32_t global_index = blockIdx.x * blockDim.x + threadIdx.x;
+    const uint8_t *input = (const uint8_t *) blockTemplate;
+    const uint8_t *raw_hash = ((const uint8_t *) hashes) + global_index * 32;
+
+    uint64_t message[64] = { 0 };
+    uint8_t *msg = (uint8_t *) message;
+
+    for (uint32_t i = 0; i < blockTemplate_len; ++i) {
+        msg[i] = input[i];
+    }
+
+    for (uint32_t i = 0; i < RANDOMX_HASH_SIZE; ++i) {
+        msg[blockTemplate_len + i] = raw_hash[i];
+    }
+
+    const uint32_t total_len = blockTemplate_len + RANDOMX_HASH_SIZE;
+    uint64_t commitment[4] = { 0 };
+    blake2b_512_process_big_block<RANDOMX_HASH_SIZE>(commitment, message, total_len, start_nonce + global_index, nonce_offset);
+
+    uint64_t *out = ((uint64_t *) hashes) + global_index * (RANDOMX_HASH_SIZE / sizeof(uint64_t));
+    out[0] = commitment[0];
+    out[1] = commitment[1];
+    out[2] = commitment[2];
+    out[3] = commitment[3];
+}
+
+__global__ void blake2b_hash_commitment_double(void *hashes, const void *blockTemplate, uint32_t blockTemplate_len, uint32_t start_nonce, uint32_t nonce_offset)
+{
+    const uint32_t global_index = blockIdx.x * blockDim.x + threadIdx.x;
+    const uint8_t *input = (const uint8_t *) blockTemplate;
+    const uint8_t *raw_hash = ((const uint8_t *) hashes) + global_index * 32;
+
+    uint64_t blocks[32] = { 0 };
+    uint8_t *msg = (uint8_t *) blocks;
+
+    for (uint32_t i = 0; i < blockTemplate_len; ++i) {
+        msg[i] = input[i];
+    }
+
+    const uint32_t nonce = start_nonce + global_index;
+    msg[nonce_offset + 0] = static_cast<uint8_t>(nonce);
+    msg[nonce_offset + 1] = static_cast<uint8_t>(nonce >> 8);
+    msg[nonce_offset + 2] = static_cast<uint8_t>(nonce >> 16);
+    msg[nonce_offset + 3] = static_cast<uint8_t>(nonce >> 24);
+
+    for (uint32_t i = 0; i < RANDOMX_HASH_SIZE; ++i) {
+        msg[blockTemplate_len + i] = raw_hash[i];
+    }
+
+    const uint32_t total_len = blockTemplate_len + RANDOMX_HASH_SIZE;
+    if (total_len % sizeof(uint64_t)) {
+        blocks[total_len / sizeof(uint64_t)] &= uint64_t(-1) >> (64 - (total_len % sizeof(uint64_t)) * 8);
+    }
+
+    uint64_t commitment[4] = { 0 };
+    blake2b_512_process_double_block<RANDOMX_HASH_SIZE>(commitment, blocks, blocks, total_len);
+
+    uint64_t *out = ((uint64_t *) hashes) + global_index * (RANDOMX_HASH_SIZE / sizeof(uint64_t));
+    out[0] = commitment[0];
+    out[1] = commitment[1];
+    out[2] = commitment[2];
+    out[3] = commitment[3];
+}
+#endif
+
 void hash(nvid_ctx *ctx, uint32_t nonce, uint32_t nonce_offset, uint64_t target, uint32_t *rescount, uint32_t *resnonce, uint32_t batch_size)
 {
     if (ctx->inputlen <= 128) {
@@ -62,6 +168,19 @@ void hash(nvid_ctx *ctx, uint32_t nonce, uint32_t nonce_offset, uint64_t target,
             CUDA_CHECK_KERNEL(ctx->device_id, blake2b_hash_registers<REGISTERS_SIZE, VM_STATE_SIZE, 64><<<batch_size / 32, 32>>>(ctx->d_rx_hashes, ctx->d_rx_vm_states));
         }
     }
+
+#if RANDOMX_TWEAK_V2_COMMITMENT
+    const uint32_t commitment_size = ctx->inputlen + RANDOMX_HASH_SIZE;
+    if (commitment_size <= 128) {
+        CUDA_CHECK_KERNEL(ctx->device_id, blake2b_hash_commitment_single<<<batch_size / 32, 32>>>(ctx->d_rx_hashes, ctx->d_input, ctx->inputlen, nonce, nonce_offset));
+    }
+    else if (commitment_size <= 256) {
+        CUDA_CHECK_KERNEL(ctx->device_id, blake2b_hash_commitment_double<<<batch_size / 32, 32>>>(ctx->d_rx_hashes, ctx->d_input, ctx->inputlen, nonce, nonce_offset));
+    }
+    else {
+        CUDA_CHECK_KERNEL(ctx->device_id, blake2b_hash_commitment_big<<<batch_size / 32, 32>>>(ctx->d_rx_hashes, ctx->d_input, ctx->inputlen, nonce, nonce_offset));
+    }
+#endif
 
     CUDA_CHECK(ctx->device_id, cudaMemset(ctx->d_result_nonce, 0, 10 * sizeof(uint32_t)));
     CUDA_CHECK_KERNEL(ctx->device_id, find_shares<<<batch_size / 32, 32>>>(ctx->d_rx_hashes, target, ctx->d_result_nonce));

--- a/src/RandomX/monero_v2/configuration.h
+++ b/src/RandomX/monero_v2/configuration.h
@@ -1,0 +1,39 @@
+/*
+Copyright (c) 2018-2019, tevador <tevador@gmail.com>
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+	* Redistributions of source code must retain the above copyright
+	  notice, this list of conditions and the following disclaimer.
+	* Redistributions in binary form must reproduce the above copyright
+	  notice, this list of conditions and the following disclaimer in the
+	  documentation and/or other materials provided with the distribution.
+	* Neither the name of the copyright holder nor the
+	  names of its contributors may be used to endorse or promote products
+	  derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#pragma once
+
+#include "../monero/configuration.h"
+
+#undef RANDOMX_PROGRAM_SIZE
+#define RANDOMX_PROGRAM_SIZE 384
+
+#define RANDOMX_TWEAK_V2_CFROUND 1
+#define RANDOMX_TWEAK_V2_AES 1
+#define RANDOMX_TWEAK_V2_PREFETCH 1
+#define RANDOMX_TWEAK_V2_COMMITMENT 1

--- a/src/RandomX/monero_v2/randomx_monero_v2.cu
+++ b/src/RandomX/monero_v2/randomx_monero_v2.cu
@@ -1,0 +1,33 @@
+/*
+Copyright (c) 2019 SChernykh
+
+This file is part of RandomX CUDA.
+
+RandomX CUDA is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+RandomX CUDA is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with RandomX CUDA.  If not, see<http://www.gnu.org/licenses/>.
+*/
+
+#include "cryptonight.h"
+#include "cuda_device.hpp"
+
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <cstdint>
+
+
+namespace RandomX_MoneroV2 {
+    #include "configuration.h"
+    #define fillAes4Rx4 fillAes4Rx4_v104
+    #include "RandomX/common.hpp"
+}

--- a/src/RandomX/randomx.cu
+++ b/src/RandomX/randomx.cu
@@ -29,6 +29,9 @@ along with RandomX CUDA.  If not, see<http://www.gnu.org/licenses/>.
 
 void randomx_prepare(nvid_ctx *ctx, const void *dataset, size_t dataset_size, uint32_t batch_size)
 {
+    constexpr size_t kMaxEntropySize = 3200;
+    constexpr size_t kMaxVmStateSize = 3072;
+
     ctx->rx_batch_size      = batch_size;
     ctx->d_scratchpads_size = batch_size * (ctx->algorithm.l3() + 64);
 
@@ -42,8 +45,8 @@ void randomx_prepare(nvid_ctx *ctx, const void *dataset, size_t dataset_size, ui
 
     CUDA_CHECK(ctx->device_id, cudaMalloc(&ctx->d_long_state, ctx->d_scratchpads_size));
     CUDA_CHECK(ctx->device_id, cudaMalloc(&ctx->d_rx_hashes, batch_size * 64));
-    CUDA_CHECK(ctx->device_id, cudaMalloc(&ctx->d_rx_entropy, batch_size * (128 + 2560)));
-    CUDA_CHECK(ctx->device_id, cudaMalloc(&ctx->d_rx_vm_states, batch_size * 2560));
+    CUDA_CHECK(ctx->device_id, cudaMalloc(&ctx->d_rx_entropy, batch_size * kMaxEntropySize));
+    CUDA_CHECK(ctx->device_id, cudaMalloc(&ctx->d_rx_vm_states, batch_size * kMaxVmStateSize));
     CUDA_CHECK(ctx->device_id, cudaMalloc(&ctx->d_rx_rounding, batch_size * sizeof(uint32_t)));
 }
 

--- a/src/RandomX/randomx_cuda.hpp
+++ b/src/RandomX/randomx_cuda.hpp
@@ -61,6 +61,11 @@ __device__ T bit_cast(double value)
 	return static_cast<T>(__double_as_longlong(value));
 }
 
+__device__ uint64_t rotr64_dynamic(uint64_t value, uint32_t shift)
+{
+	return shift == 0 ? value : ((value >> shift) | (value << (64 - shift)));
+}
+
 __device__ double load_F_E_groups(int value, uint64_t andMask, uint64_t orMask)
 {
 	uint64_t x = bit_cast<uint64_t>(__int2double_rn(value));
@@ -68,6 +73,79 @@ __device__ double load_F_E_groups(int value, uint64_t andMask, uint64_t orMask)
 	x |= orMask;
 	return __longlong_as_double(static_cast<int64_t>(x));
 }
+
+#if RANDOMX_TWEAK_V2_AES
+__device__ uint32_t byte32(uint32_t value, uint32_t shift)
+{
+	return (value >> shift) & 0xFFU;
+}
+
+__device__ void aesenc_round(uint32_t state[4], const uint32_t key[4])
+{
+	uint32_t out[4];
+
+	out[0] = AES_TABLE[byte32(state[0],  0)] ^ AES_TABLE[256 + byte32(state[3],  8)] ^ AES_TABLE[512 + byte32(state[2], 16)] ^ AES_TABLE[768 + byte32(state[1], 24)] ^ key[0];
+	out[1] = AES_TABLE[byte32(state[1],  0)] ^ AES_TABLE[256 + byte32(state[0],  8)] ^ AES_TABLE[512 + byte32(state[3], 16)] ^ AES_TABLE[768 + byte32(state[2], 24)] ^ key[1];
+	out[2] = AES_TABLE[byte32(state[2],  0)] ^ AES_TABLE[256 + byte32(state[1],  8)] ^ AES_TABLE[512 + byte32(state[0], 16)] ^ AES_TABLE[768 + byte32(state[3], 24)] ^ key[2];
+	out[3] = AES_TABLE[byte32(state[3],  0)] ^ AES_TABLE[256 + byte32(state[2],  8)] ^ AES_TABLE[512 + byte32(state[1], 16)] ^ AES_TABLE[768 + byte32(state[0], 24)] ^ key[3];
+
+	state[0] = out[0];
+	state[1] = out[1];
+	state[2] = out[2];
+	state[3] = out[3];
+}
+
+__device__ void aesdec_round(uint32_t state[4], const uint32_t key[4])
+{
+	uint32_t out[4];
+
+	out[0] = AES_TABLE[1024 + byte32(state[0],  0)] ^ AES_TABLE[1280 + byte32(state[1],  8)] ^ AES_TABLE[1536 + byte32(state[2], 16)] ^ AES_TABLE[1792 + byte32(state[3], 24)] ^ key[0];
+	out[1] = AES_TABLE[1024 + byte32(state[1],  0)] ^ AES_TABLE[1280 + byte32(state[2],  8)] ^ AES_TABLE[1536 + byte32(state[3], 16)] ^ AES_TABLE[1792 + byte32(state[0], 24)] ^ key[1];
+	out[2] = AES_TABLE[1024 + byte32(state[2],  0)] ^ AES_TABLE[1280 + byte32(state[3],  8)] ^ AES_TABLE[1536 + byte32(state[0], 16)] ^ AES_TABLE[1792 + byte32(state[1], 24)] ^ key[2];
+	out[3] = AES_TABLE[1024 + byte32(state[3],  0)] ^ AES_TABLE[1280 + byte32(state[0],  8)] ^ AES_TABLE[1536 + byte32(state[1], 16)] ^ AES_TABLE[1792 + byte32(state[2], 24)] ^ key[3];
+
+	state[0] = out[0];
+	state[1] = out[1];
+	state[2] = out[2];
+	state[3] = out[3];
+}
+
+__device__ uint64_t mix_F_E_groups_v2(const double *F, const double *E, int32_t sub)
+{
+	const int32_t reg = sub >> 1;
+	const uint64_t f0 = bit_cast<uint64_t>(F[reg * 2]);
+	const uint64_t f1 = bit_cast<uint64_t>(F[reg * 2 + 1]);
+	uint32_t state[4] = {
+		static_cast<uint32_t>(f0),
+		static_cast<uint32_t>(f0 >> 32),
+		static_cast<uint32_t>(f1),
+		static_cast<uint32_t>(f1 >> 32)
+	};
+
+	for (int32_t round = 0; round < 4; ++round) {
+		const uint64_t e0 = bit_cast<uint64_t>(E[round * 2]);
+		const uint64_t e1 = bit_cast<uint64_t>(E[round * 2 + 1]);
+		const uint32_t key[4] = {
+			static_cast<uint32_t>(e0),
+			static_cast<uint32_t>(e0 >> 32),
+			static_cast<uint32_t>(e1),
+			static_cast<uint32_t>(e1 >> 32)
+		};
+
+		if ((reg & 1) == 0) {
+			aesenc_round(state, key);
+		}
+		else {
+			aesdec_round(state, key);
+		}
+	}
+
+	const uint64_t lo = static_cast<uint64_t>(state[0]) | (static_cast<uint64_t>(state[1]) << 32);
+	const uint64_t hi = static_cast<uint64_t>(state[2]) | (static_cast<uint64_t>(state[3]) << 32);
+
+	return (sub & 1) == 0 ? lo : hi;
+}
+#endif
 
 __device__ void test_memory_access(uint64_t* r, uint8_t* scratchpad, uint32_t batch_size)
 {
@@ -2024,7 +2102,14 @@ __device__ void inner_loop(
 				else if (ROUNDING_MODE < 0)
 				{
 					asm("// CFROUND (1/256) ------>");
-					imm_buf[IMM_INDEX_COUNT + 1] = ((src >> imm_offset) | (src << (64 - imm_offset))) & 3;
+					const uint64_t rotated_src = rotr64_dynamic(src, imm_offset);
+#if RANDOMX_TWEAK_V2_CFROUND
+					if ((rotated_src & 60) == 0) {
+						imm_buf[IMM_INDEX_COUNT + 1] = rotated_src & 3;
+					}
+#else
+					imm_buf[IMM_INDEX_COUNT + 1] = rotated_src & 3;
+#endif
 					asm("// <------ CFROUND (1/256)");
 					goto execution_end;
 				}
@@ -2169,14 +2254,25 @@ __global__ void __launch_bounds__((WORKERS_PER_HASH == 16) ? 32 : 16, 16) execut
 
 		if ((WORKERS_PER_HASH <= 8) || (sub < 8))
 		{
+			const uint32_t readPtr = ma;
+
+#if RANDOMX_TWEAK_V2_PREFETCH
+			ma ^= *readReg2 ^ *readReg3;
+			ma &= CacheLineAlignMask;
+#else
 			mx ^= *readReg2 ^ *readReg3;
 			mx &= CacheLineAlignMask;
+#endif
 
-			const uint64_t next_r = *r ^ *(const uint64_t*)(dataset + ma + sub * 8);
+			const uint64_t next_r = *r ^ *(const uint64_t*)(dataset + readPtr + sub * 8);
 			*r = next_r;
 
 			*p1 = next_r;
+#if RANDOMX_TWEAK_V2_AES
+			*p0 = mix_F_E_groups_v2(F, E, sub);
+#else
 			*p0 = bit_cast<uint64_t>(f[0]) ^ bit_cast<uint64_t>(e[0]);
+#endif
 
 			uint32_t tmp = ma;
 			ma = mx;

--- a/src/crypto/common/Algorithm.cpp
+++ b/src/crypto/common/Algorithm.cpp
@@ -43,7 +43,7 @@ xmrig_cuda::Algorithm::Id xmrig_cuda::Algorithm::parse(uint32_t id)
         CN_UPX2,
 #       endif
 #       ifdef XMRIG_ALGO_RANDOMX
-        RX_0, RX_WOW, RX_ARQ, RX_GRAFT, RX_SFX, RX_YADA,
+        RX_0, RX_V2, RX_WOW, RX_ARQ, RX_GRAFT, RX_SFX, RX_YADA,
 #       endif
 #       ifdef XMRIG_ALGO_ARGON2
         AR2_CHUKWA, AR2_CHUKWA_V2, AR2_WRKZ,

--- a/src/crypto/common/Algorithm.h
+++ b/src/crypto/common/Algorithm.h
@@ -55,6 +55,7 @@ public:
         CN_PICO_TLO     = 0x63120274,   // "cn-pico/tlo"      CryptoNight-Pico (TLO)
         CN_UPX2         = 0x63110200,   // "cn/upx2"          Uplexa (UPX2)
         RX_0            = 0x72151200,   // "rx/0"             RandomX (reference configuration).
+        RX_V2           = 0x72151202,   // "rx/2"             RandomX (Monero v2).
         RX_WOW          = 0x72141177,   // "rx/wow"           RandomWOW (Wownero).
         RX_ARQ          = 0x72121061,   // "rx/arq"           RandomARQ (Arqma).
         RX_GRAFT        = 0x72151267,   // "rx/graft"         RandomGRAFT (Graft).

--- a/src/cryptonight.h
+++ b/src/cryptonight.h
@@ -124,6 +124,7 @@ void randomx_update_dataset(nvid_ctx* ctx, const void* dataset, size_t dataset_s
 
 namespace RandomX_Arqma   { void hash(nvid_ctx *ctx, uint32_t nonce, uint32_t nonce_offset, uint64_t target, uint32_t *rescount, uint32_t *resnonce, uint32_t batch_size); }
 namespace RandomX_Monero  { void hash(nvid_ctx *ctx, uint32_t nonce, uint32_t nonce_offset, uint64_t target, uint32_t *rescount, uint32_t *resnonce, uint32_t batch_size); }
+namespace RandomX_MoneroV2 { void hash(nvid_ctx *ctx, uint32_t nonce, uint32_t nonce_offset, uint64_t target, uint32_t *rescount, uint32_t *resnonce, uint32_t batch_size); }
 namespace RandomX_Wownero { void hash(nvid_ctx *ctx, uint32_t nonce, uint32_t nonce_offset, uint64_t target, uint32_t *rescount, uint32_t *resnonce, uint32_t batch_size); }
 namespace RandomX_Graft   { void hash(nvid_ctx *ctx, uint32_t nonce, uint32_t nonce_offset, uint64_t target, uint32_t *rescount, uint32_t *resnonce, uint32_t batch_size); }
 namespace RandomX_Yada    { void hash(nvid_ctx* ctx, uint32_t nonce, uint32_t nonce_offset, uint64_t target, uint32_t* rescount, uint32_t* resnonce, uint32_t batch_size); }

--- a/src/cuda_extra.cu
+++ b/src/cuda_extra.cu
@@ -551,11 +551,17 @@ int cuda_get_deviceinfo(nvid_ctx *ctx)
     ctx->device_mpcount         = props.multiProcessorCount;
     ctx->device_arch[0]         = props.major;
     ctx->device_arch[1]         = props.minor;
-    ctx->device_clockRate       = props.clockRate;
-    ctx->device_memoryClockRate = props.memoryClockRate;
     ctx->device_pciBusID        = props.pciBusID;
     ctx->device_pciDeviceID     = props.pciDeviceID;
     ctx->device_pciDomainID     = props.pciDomainID;
+
+#   if CUDART_VERSION >= 13000
+    CUDA_CHECK(ctx->device_id, cudaDeviceGetAttribute(&ctx->device_clockRate, cudaDevAttrClockRate, ctx->device_id));
+    CUDA_CHECK(ctx->device_id, cudaDeviceGetAttribute(&ctx->device_memoryClockRate, cudaDevAttrMemoryClockRate, ctx->device_id));
+#   else
+    ctx->device_clockRate       = props.clockRate;
+    ctx->device_memoryClockRate = props.memoryClockRate;
+#   endif
 
     if ((ctx->algorithm.family() == Algorithm::RANDOM_X) && ((ctx->device_blocks < 0) || (ctx->device_threads < 0))) {
         ctx->device_threads = 32;

--- a/src/xmrig-cuda.cpp
+++ b/src/xmrig-cuda.cpp
@@ -188,6 +188,10 @@ bool rxHash(nvid_ctx *ctx, uint32_t startNonce, uint64_t target, uint32_t *resco
             RandomX_Monero::hash(ctx, startNonce, 39, target, rescount, resnonce, ctx->rx_batch_size);
             break;
 
+        case Algorithm::RX_V2:
+            RandomX_MoneroV2::hash(ctx, startNonce, 39, target, rescount, resnonce, ctx->rx_batch_size);
+            break;
+
         case Algorithm::RX_WOW:
             RandomX_Wownero::hash(ctx, startNonce, 39, target, rescount, resnonce, ctx->rx_batch_size);
             break;


### PR DESCRIPTION
  Required for `rx/2` GPU support.

  `JobResults` rechecks GPU nonces on CPU. For `rx/2`, this must use the commitment instead of the
  raw RandomX hash, otherwise valid GPU shares are reported as compute errors.

  Other algorithms are unchanged.