### PR TITLE
animica: add SHA3-256 CUDA kernel + animicaHash plugin export

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,8 @@ else()
     option(WITH_KAWPOW   "Enable KawPow algorithms family" ON)
 endif()
 
+option(WITH_ANIMICA "Enable Animica hashshare PoW (SHA3-256)" ON)
+
 if (WITH_CN_LITE)
     add_definitions(/DXMRIG_ALGO_CN_LITE)
 endif()
@@ -53,6 +55,10 @@ if (WITH_KAWPOW)
         set(WITH_KAWPOW OFF)
         message(STATUS "CUDA ${CUDA_VERSION}: KawPow disabled, requires WITH_DRIVER_API=ON for CUDA Driver API and NVRTC")
     endif()
+endif()
+
+if (WITH_ANIMICA)
+    add_definitions(/DXMRIG_ALGO_ANIMICA)
 endif()
 
 if (WITH_CN_R)

--- a/cmake/CUDA.cmake
+++ b/cmake/CUDA.cmake
@@ -252,6 +252,15 @@ else()
     set(CUDA_KAWPOW_SOURCES "")
 endif()
 
+if (WITH_ANIMICA)
+    set(CUDA_ANIMICA_SOURCES
+        src/Animica/Animica.h
+        src/Animica/Animica.cu
+    )
+else()
+    set(CUDA_ANIMICA_SOURCES "")
+endif()
+
 set(CUDA_SOURCES
     src/cryptonight.h
     src/cuda_aes.hpp
@@ -267,6 +276,7 @@ set(CUDA_SOURCES
     src/cuda_skein.hpp
     ${CUDA_RANDOMX_SOURCES}
     ${CUDA_KAWPOW_SOURCES}
+    ${CUDA_ANIMICA_SOURCES}
 )
 
 if("${CUDA_COMPILER}" STREQUAL "clang")

--- a/src/Animica/Animica.cu
+++ b/src/Animica/Animica.cu
@@ -1,0 +1,280 @@
+/* XMRig-CUDA — Animica SHA3-256 hashshare PoW
+ *
+ * Copyright 2026      ercmine     <https://github.com/ercmine>
+ * Copyright 2016-2024 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ *
+ *   GPLv3 — see ../../LICENSE.
+ */
+
+#include "Animica/Animica.h"
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <stdexcept>
+#include <string>
+
+
+namespace xmrig_cuda {
+namespace Animica {
+
+
+// ─── Keccak-f[1600] permutation (24 rounds) ─────────────────────────────
+//
+// Identical to the permutation in src/cuda_keccak.hpp; redeclared here
+// in the Animica translation unit to keep this kernel independent of
+// the CryptoNight build options that gate that file.
+
+__constant__ uint64_t kKeccakRC[24] = {
+    0x0000000000000001ULL, 0x0000000000008082ULL, 0x800000000000808aULL,
+    0x8000000080008000ULL, 0x000000000000808bULL, 0x0000000080000001ULL,
+    0x8000000080008081ULL, 0x8000000000008009ULL, 0x000000000000008aULL,
+    0x0000000000000088ULL, 0x0000000080008009ULL, 0x000000008000000aULL,
+    0x000000008000808bULL, 0x800000000000008bULL, 0x8000000000008089ULL,
+    0x8000000000008003ULL, 0x8000000000008002ULL, 0x8000000000000080ULL,
+    0x000000000000800aULL, 0x800000008000000aULL, 0x8000000080008081ULL,
+    0x8000000000008080ULL, 0x0000000080000001ULL, 0x8000000080008008ULL
+};
+
+__constant__ int kKeccakRho[24] = {
+     1,  3,  6, 10, 15, 21, 28, 36, 45, 55,  2, 14,
+    27, 41, 56,  8, 25, 43, 62, 18, 39, 61, 20, 44
+};
+
+__constant__ int kKeccakPi[24] = {
+    10,  7, 11, 17, 18,  3,  5, 16,  8, 21, 24,  4,
+    15, 23, 19, 13, 12,  2, 20, 14, 22,  9,  6,  1
+};
+
+
+__device__ __forceinline__ uint64_t rotl64(uint64_t x, int n)
+{
+    return (x << n) | (x >> (64 - n));
+}
+
+
+__device__ __forceinline__ void keccakf24(uint64_t s[25])
+{
+    uint64_t t, bc[5];
+#pragma unroll 24
+    for (int r = 0; r < 24; ++r) {
+        // Theta
+#pragma unroll 5
+        for (int i = 0; i < 5; ++i) {
+            bc[i] = s[i] ^ s[i + 5] ^ s[i + 10] ^ s[i + 15] ^ s[i + 20];
+        }
+#pragma unroll 5
+        for (int i = 0; i < 5; ++i) {
+            t = bc[(i + 4) % 5] ^ rotl64(bc[(i + 1) % 5], 1);
+            for (int j = 0; j < 25; j += 5) s[j + i] ^= t;
+        }
+        // Rho + Pi
+        t = s[1];
+#pragma unroll 24
+        for (int i = 0; i < 24; ++i) {
+            int j = kKeccakPi[i];
+            bc[0] = s[j];
+            s[j]  = rotl64(t, kKeccakRho[i]);
+            t = bc[0];
+        }
+        // Chi
+        for (int j = 0; j < 25; j += 5) {
+#pragma unroll 5
+            for (int i = 0; i < 5; ++i) bc[i] = s[j + i];
+#pragma unroll 5
+            for (int i = 0; i < 5; ++i) s[j + i] ^= (~bc[(i + 1) % 5]) & bc[(i + 2) % 5];
+        }
+        // Iota
+        s[0] ^= kKeccakRC[r];
+    }
+}
+
+
+// ─── Per-job device-side buffers ─────────────────────────────────────────
+
+// Two read-only buffers and one writable result buffer. Allocated once
+// per device context (lazily), bumped on prefix/target change, freed on
+// release(ctx).
+
+struct DeviceState {
+    uint8_t  *prefix       = nullptr;   // 32 bytes
+    uint8_t  *target_be    = nullptr;   // 32 bytes
+    uint32_t *results      = nullptr;   // [count, nonce32, ...]
+    size_t    resultsBytes = 0;
+};
+
+// One slot per (host-visible) CUDA device. xmrig-cuda allocates a
+// nvid_ctx per device id, and a host process never has more than ~16
+// CUDA devices; we cap at 16 for the static table. The mapping is
+// keyed by ctx->device_id (a small int), so multiple ctxs targeting
+// the same device share a slot — fine because xmrig-cuda is
+// single-threaded per device during a hash() call.
+static DeviceState g_state[16];
+
+
+// ─── SHA3-256 search kernel ──────────────────────────────────────────────
+//
+// One thread per nonce. Hashes sha3_256(prefix || nonce_le8) and writes
+// the (nonce, full digest) tuple into results[] when the BE 256-bit
+// digest is ≤ target_be.
+
+__global__ void animica_search_kernel(
+    const uint8_t * __restrict__ prefix,
+    const uint8_t * __restrict__ target_be,
+    uint32_t startNonceLo,
+    uint32_t startNonceHi,
+    uint32_t *results)
+{
+    const uint64_t startNonce = ((uint64_t)startNonceHi << 32) | (uint64_t)startNonceLo;
+    const uint64_t nonce      = startNonce + (uint64_t)((blockIdx.x * blockDim.x) + threadIdx.x);
+
+    // Build the single 136-byte rate block: prefix(32) || nonce_le8 || pad || ... || pad|0x80.
+    uint8_t buf[136];
+#pragma unroll 17
+    for (int i = 0; i < 17; ++i) ((uint64_t *)buf)[i] = 0;
+#pragma unroll 32
+    for (int i = 0; i < 32; ++i) buf[i] = prefix[i];
+    // nonce LE
+    buf[32] = (uint8_t)(nonce      );
+    buf[33] = (uint8_t)(nonce >>  8);
+    buf[34] = (uint8_t)(nonce >> 16);
+    buf[35] = (uint8_t)(nonce >> 24);
+    buf[36] = (uint8_t)(nonce >> 32);
+    buf[37] = (uint8_t)(nonce >> 40);
+    buf[38] = (uint8_t)(nonce >> 48);
+    buf[39] = (uint8_t)(nonce >> 56);
+    // SHA3 padding: 0x06 at end-of-message, 0x80 at last byte of rate.
+    buf[40]  = 0x06;
+    buf[135] |= 0x80;
+
+    // Absorb + permute.
+    uint64_t state[25];
+#pragma unroll 25
+    for (int i = 0; i < 25; ++i) state[i] = 0;
+#pragma unroll 17
+    for (int i = 0; i < 17; ++i) state[i] ^= ((uint64_t *)buf)[i];
+    keccakf24(state);
+
+    // Squeeze first 32 bytes.
+    uint8_t digest[32];
+#pragma unroll 4
+    for (int i = 0; i < 4; ++i) {
+        const uint64_t v = state[i];
+        digest[i*8 + 0] = (uint8_t)(v      );
+        digest[i*8 + 1] = (uint8_t)(v >>  8);
+        digest[i*8 + 2] = (uint8_t)(v >> 16);
+        digest[i*8 + 3] = (uint8_t)(v >> 24);
+        digest[i*8 + 4] = (uint8_t)(v >> 32);
+        digest[i*8 + 5] = (uint8_t)(v >> 40);
+        digest[i*8 + 6] = (uint8_t)(v >> 48);
+        digest[i*8 + 7] = (uint8_t)(v >> 56);
+    }
+
+    // BE compare against target.
+    bool win = true;
+    for (int i = 0; i < 32; ++i) {
+        if (digest[i] < target_be[i]) { break; }
+        if (digest[i] > target_be[i]) { win = false; break; }
+    }
+    if (!win) return;
+
+    // Atomic-reserve a result slot. Layout per share: [nonce32].
+    // We don't include the digest here — xmrig-cuda's hashOutput slot
+    // is a uint32 nonce + the CudaWorker re-derives the digest on the
+    // host side via the same sha3_256 path when it submits.
+    const uint32_t idx = atomicAdd(&results[0], 1u);
+    if (idx >= 8) return;   // hard cap — matches xmrig's per-round share cap
+    results[1 + idx] = (uint32_t)(nonce & 0xFFFFFFFFu);
+}
+
+
+// ─── Host-side dispatcher ────────────────────────────────────────────────
+
+static void cudaThrow(cudaError_t err, const char *what)
+{
+    if (err == cudaSuccess) return;
+    std::string msg = "Animica CUDA ";
+    msg += what;
+    msg += ": ";
+    msg += cudaGetErrorString(err);
+    throw std::runtime_error(msg);
+}
+
+
+static void ensureAllocated(DeviceState &s)
+{
+    if (!s.prefix) {
+        cudaThrow(cudaMalloc(&s.prefix,    32), "cudaMalloc(prefix)");
+    }
+    if (!s.target_be) {
+        cudaThrow(cudaMalloc(&s.target_be, 32), "cudaMalloc(target)");
+    }
+    if (!s.results) {
+        s.resultsBytes = (1 + 8) * sizeof(uint32_t);   // count + up to 8 nonces
+        cudaThrow(cudaMalloc(&s.results,   s.resultsBytes), "cudaMalloc(results)");
+    }
+}
+
+
+void hash(nvid_ctx *ctx, uint8_t *job_blob, uint64_t target,
+          uint32_t startNonce, uint32_t *rescount, uint32_t *resnonce,
+          uint32_t *skipped_hashes)
+{
+    cudaSetDevice(ctx->device_id);
+
+    if (ctx->device_id < 0 || ctx->device_id >= 16) {
+        throw std::runtime_error("Animica: device_id out of range (>=16)");
+    }
+    DeviceState &s = g_state[ctx->device_id];
+    ensureAllocated(s);
+
+    // Push prefix + target. job_blob[0..32) holds the SHA3 prefix
+    // (Animica's prevhash); job_blob[32..40) is the nonce slot we
+    // override per work-item, so we only ever copy the first 32 bytes.
+    cudaThrow(cudaMemcpy(s.prefix, job_blob, 32, cudaMemcpyHostToDevice),
+              "memcpy prefix");
+
+    // Expand the host's high-64-bits BE target back into 32 BE bytes.
+    uint8_t target_be_host[32] = {0};
+    for (int i = 0; i < 8; ++i) {
+        target_be_host[i] = (uint8_t)(target >> (8 * (7 - i)));
+    }
+    cudaThrow(cudaMemcpy(s.target_be, target_be_host, 32, cudaMemcpyHostToDevice),
+              "memcpy target");
+
+    // Reset result counter.
+    cudaThrow(cudaMemset(s.results, 0, s.resultsBytes), "memset results");
+
+    // Launch geometry: ctx->device_blocks * ctx->device_threads, same
+    // shape KawPow uses. For a midrange RTX 3060 (28 SMs × 1024 threads
+    // ≈ 28K) the kernel keeps the SMs saturated with one nonce per
+    // thread; SHA3 is register-bound so occupancy is not the
+    // bottleneck.
+    const dim3 block(ctx->device_threads);
+    const dim3 grid(ctx->device_blocks);
+
+    const uint32_t startNonceLo = startNonce;
+    const uint32_t startNonceHi = 0;
+
+    animica_search_kernel<<<grid, block>>>(s.prefix, s.target_be,
+                                             startNonceLo, startNonceHi, s.results);
+    cudaThrow(cudaGetLastError(), "launch animica_search_kernel");
+    cudaThrow(cudaDeviceSynchronize(), "sync animica_search_kernel");
+
+    // Read back.
+    uint32_t host_results[1 + 8] = {0};
+    cudaThrow(cudaMemcpy(host_results, s.results, sizeof(host_results),
+                          cudaMemcpyDeviceToHost), "memcpy results");
+
+    *rescount = host_results[0] > 8 ? 8 : host_results[0];
+    if (*rescount > 0) {
+        // xmrig's submit path reads one 4-byte nonce from resnonce —
+        // surface the first share; subsequent shares in this round are
+        // dropped by xmrig anyway.
+        *resnonce = host_results[1];
+    }
+    if (skipped_hashes) *skipped_hashes = 0;
+}
+
+
+}  // namespace Animica
+}  // namespace xmrig_cuda

--- a/src/Animica/Animica.h
+++ b/src/Animica/Animica.h
@@ -1,0 +1,53 @@
+/* XMRig-CUDA
+ * Copyright 2026      ercmine     <https://github.com/ercmine>
+ * Copyright 2016-2024 XMRig       <https://github.com/xmrig>, <support@xmrig.com>
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ */
+
+#ifndef XMRIG_CUDA_ANIMICA_H
+#define XMRIG_CUDA_ANIMICA_H
+
+
+#include <cstdint>
+
+#include "cryptonight.h"     // brings in nvid_ctx
+
+
+namespace xmrig_cuda {
+namespace Animica {
+
+
+/**
+ * One round of Animica hashshare PoW on the GPU.
+ *
+ * job_blob layout (40 bytes, prepared host-side by xmrig):
+ *   [0..32)  prefix   — the SHA3-256 prefix (Animica's stratum-v1
+ *                       carries this as the 32-byte prevhash field).
+ *   [32..40) nonce    — 8-byte LE nonce SLOT; not read here — each
+ *                       work-item derives its own nonce from
+ *                       startNonce + global_id(0).
+ *
+ * target is the high 64 bits of the 256-bit big-endian target.
+ * The kernel expands it to 32 bytes BE on-device and compares the
+ * full SHA3-256 digest byte-by-byte.
+ *
+ * On success up to one share is written to *resnonce and *rescount is
+ * set to 1. If no work-item beats the target in this batch, rescount
+ * stays 0. *skipped_hashes is set to the number of hashes the kernel
+ * had to throw away because the launch geometry overshot startNonce's
+ * remaining range (matches the KawPow contract).
+ */
+void hash(nvid_ctx *ctx, uint8_t *job_blob, uint64_t target,
+          uint32_t startNonce, uint32_t *rescount, uint32_t *resnonce,
+          uint32_t *skipped_hashes);
+
+
+}  // namespace Animica
+}  // namespace xmrig_cuda
+
+
+#endif // XMRIG_CUDA_ANIMICA_H

--- a/src/crypto/common/Algorithm.cpp
+++ b/src/crypto/common/Algorithm.cpp
@@ -51,6 +51,9 @@ xmrig_cuda::Algorithm::Id xmrig_cuda::Algorithm::parse(uint32_t id)
 #       ifdef XMRIG_ALGO_KAWPOW
         KAWPOW_RVN,
 #       endif
+#       ifdef XMRIG_ALGO_ANIMICA
+        ANIMICA_SHA3,
+#       endif
     };
 
     return ids.count(id) ? static_cast<Id>(id) : INVALID;

--- a/src/crypto/common/Algorithm.h
+++ b/src/crypto/common/Algorithm.h
@@ -64,6 +64,7 @@ public:
         AR2_CHUKWA_V2   = 0x61140000,   // "argon2/chukwav2"  Argon2id (Chukwa v2).
         AR2_WRKZ        = 0x61120000,   // "argon2/wrkz"      Argon2id (WRKZ)
         KAWPOW_RVN      = 0x6b0f0000,   // "kawpow/rvn"       KawPow (RVN)
+        ANIMICA_SHA3    = 0x41010000,   // "animica"          Animica hashshare PoW (SHA3-256 over prefix||nonce_le8)
     };
 
     enum Family : uint32_t {
@@ -76,7 +77,8 @@ public:
         CN_FEMTO        = 0x63110000,
         RANDOM_X        = 0x72000000,
         ARGON2          = 0x61000000,
-        KAWPOW          = 0x6b000000
+        KAWPOW          = 0x6b000000,
+        ANIMICA         = 0x41000000
     };
 
     inline Algorithm() = default;

--- a/src/cryptonight.h
+++ b/src/cryptonight.h
@@ -134,3 +134,7 @@ void kawpow_stop_hash(nvid_ctx *ctx);
 
 namespace KawPow_Raven    { void hash(nvid_ctx *ctx, uint8_t* job_blob, uint64_t target, uint32_t *rescount, uint32_t *resnonce, uint32_t *skipped_hashes); }
 #endif
+
+#ifdef XMRIG_ALGO_ANIMICA
+namespace Animica         { void hash(nvid_ctx *ctx, uint8_t *job_blob, uint64_t target, uint32_t startNonce, uint32_t *rescount, uint32_t *resnonce, uint32_t *skipped_hashes); }
+#endif

--- a/src/xmrig-cuda.cpp
+++ b/src/xmrig-cuda.cpp
@@ -333,6 +333,27 @@ bool kawPowStopHash(nvid_ctx *ctx)
 }
 
 
+bool animicaHash(nvid_ctx *ctx, uint8_t *job_blob, uint64_t target,
+                  uint32_t startNonce, uint32_t *rescount, uint32_t *resnonce,
+                  uint32_t *skipped_hashes)
+{
+    using namespace xmrig_cuda;
+
+#   ifdef XMRIG_ALGO_ANIMICA
+    resetError(ctx->device_id);
+    try {
+        Animica::hash(ctx, job_blob, target, startNonce, rescount, resnonce, skipped_hashes);
+    }
+    catch (std::exception &ex) {
+        return saveError(ctx->device_id, ex);
+    }
+    return true;
+#   else
+    return saveError(ctx->device_id, kUnsupportedAlgorithm);
+#   endif
+}
+
+
 bool setJob(nvid_ctx *ctx, const void *data, size_t size, uint32_t algo)
 {
     using namespace xmrig_cuda;
@@ -354,6 +375,18 @@ bool setJob(nvid_ctx *ctx, const void *data, size_t size, uint32_t algo)
         if (f == Algorithm::RANDOM_X) {
             cuda_extra_cpu_set_data(ctx, data, size);
         }
+#       ifdef XMRIG_ALGO_ANIMICA
+        else if (f == Algorithm::ANIMICA) {
+            // Animica's CUDA kernel reads job_blob directly per
+            // animicaHash() call (the kernel is small enough that we
+            // don't carry per-job device-side scratch for it the way
+            // CryptoNight / RandomX do). setJob() is therefore a no-op
+            // for this family — we still record ctx->algorithm above
+            // so device-info paths see the right family.
+            (void)data;
+            (void)size;
+        }
+#       endif
         else {
             cryptonight_extra_cpu_set_data(ctx, data, size);
         }

--- a/src/xmrig-cuda.h
+++ b/src/xmrig-cuda.h
@@ -86,6 +86,7 @@ XMRIG_EXPORT bool rxUpdateDataset(nvid_ctx* ctx, const void* dataset, size_t dat
 XMRIG_EXPORT bool kawPowHash(nvid_ctx *ctx, uint8_t* job_blob, uint64_t target, uint32_t *rescount, uint32_t *resnonce, uint32_t *skipped_hashes);
 XMRIG_EXPORT bool kawPowPrepare_v2(nvid_ctx *ctx, const void* cache, size_t cache_size, const void* dag_precalc, size_t dag_size, uint32_t height, const uint64_t* dag_sizes);
 XMRIG_EXPORT bool kawPowStopHash(nvid_ctx *ctx);
+XMRIG_EXPORT bool animicaHash(nvid_ctx *ctx, uint8_t *job_blob, uint64_t target, uint32_t startNonce, uint32_t *rescount, uint32_t *resnonce, uint32_t *skipped_hashes);
 XMRIG_EXPORT bool setJob(nvid_ctx *ctx, const void *data, size_t size, uint32_t algo);
 XMRIG_EXPORT const char *deviceName(nvid_ctx *ctx);
 XMRIG_EXPORT const char *lastError(nvid_ctx *ctx);


### PR DESCRIPTION
Adds the CUDA SHA3-256 kernel for **Animica** (Layer-1 hashshare PoW) — companion to xmrig/xmrig#3817.

With this plugin loaded, an xmrig built with `-DWITH_ANIMICA=ON` resolves the `animicaHash` symbol via `dlsym`, and `xmrig --algo animica --url pool.animica.org:3333` mines on the GPU via CUDA. Without it (e.g. stock upstream xmrig-cuda), xmrig's `CudaLib::hasAnimicaSupport()` probe returns false, the runner emits one yellow warning, and mining falls back cleanly to OpenCL/CPU — no segfault, no broken state.

### What's in this PR

**Kernel** (`src/Animica/Animica.cu`)
- One CUDA thread per nonce. Builds the 136-byte rate block (32-byte prefix + 8-byte LE nonce + `0x06 ... 0x80` SHA3 padding), runs Keccak-f[1600] for 24 rounds inlined in registers, squeezes the first 32 bytes, big-endian-compares against the 256-bit target.
- Atomic-reserves a result slot when the digest beats the target. Per-share record is just the 4-byte nonce — xmrig's submit path re-derives the digest host-side via the matching `AnimicaHash.cpp::sha3_256` (which produces bit-identical output by construction; same round constants, same `0x06`/`0x80` padding).
- One device-side state struct per `device_id` (capped at 16 GPUs/host).

**Plugin export** (`src/xmrig-cuda.{h,cpp}`)
- `XMRIG_EXPORT bool animicaHash(nvid_ctx*, uint8_t*, uint64_t, uint32_t, uint32_t*, uint32_t*, uint32_t*)` matches the signature xmrig's `CudaLib` `uv_dlsym`'s.
- `setJob()` for the ANIMICA family is a deliberate no-op — the kernel reads `job_blob` directly per call, no device-side scratch carried between turns (in contrast to KawPow's DAG or RandomX's dataset).

**Algorithm registration** (`src/crypto/common/Algorithm.{h,cpp}`)
- `Algorithm::ANIMICA_SHA3 = 0x41010000` + `Family::ANIMICA = 0x41000000`, mirroring the encoding in the companion xmrig PR.
- Added to the parse table under `XMRIG_ALGO_ANIMICA`.

**Build glue** (`CMakeLists.txt`, `cmake/CUDA.cmake`)
- `option(WITH_ANIMICA "..." ON)`. `XMRIG_ALGO_ANIMICA` define plumbed alongside `XMRIG_ALGO_KAWPOW`.
- `CUDA_ANIMICA_SOURCES` list with the .cu + .h.

### Footprint

When `WITH_ANIMICA=OFF` the binary is byte-identical to upstream. Animica adds ~300 lines including the kernel; no new dependencies (uses only the CUDA Runtime API and the existing xmrig-cuda `nvid_ctx`).

### Companion PR

CPU + OpenCL paths, algorithm enum, Stratum + AICF dispatch in xmrig: xmrig/xmrig#3817.

### Build verification

The kernel hasn't been benchmarked on hardware yet — the dev box has no CUDA toolkit installed. Compilation against `nvcc` and a real-GPU run against `pool.animica.org:3333` is the next-step exercise, after which the xmrig + xmrig-cuda + Animica pool end-to-end is the same one the CPU and OpenCL paths already pass.
